### PR TITLE
Fixed a bug using optional chaining

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,63 +1,97 @@
-const express = require('express')
-const app = express()
-const http = require('http')
-const server = http.createServer(app)
-const socketio = require('socket.io')
-const io = socketio(server)
-const path = require('path')
-const { generateMessage, generateLocationMessage } = require('./utils/messages')
-const { addUser, removeUser, getUser, getUsersInRoom } = require('./utils/users')
-const publicDirectoryPath = path.join(__dirname, '../public')
-app.use(express.static(publicDirectoryPath))
-const Filter = require('bad-words')
+const express = require("express");
+const app = express();
+const http = require("http");
+const server = http.createServer(app);
+const socketio = require("socket.io");
+const io = socketio(server);
+const path = require("path");
+const {
+  generateMessage,
+  generateLocationMessage,
+} = require("./utils/messages");
+const {
+  addUser,
+  removeUser,
+  getUser,
+  getUsersInRoom,
+} = require("./utils/users");
+const publicDirectoryPath = path.join(__dirname, "../public");
+app.use(express.static(publicDirectoryPath));
+const Filter = require("bad-words");
 
-io.on('connection', (socket) => {
-  console.log('New WebSocket connection')
-  socket.on('join', (options, callbackFromChatJS) => {
-    const { error, user } = addUser({ id: socket.id , ...options })
+io.on("connection", (socket) => {
+  console.log("New WebSocket connection");
+  socket.on("join", (options, callbackFromChatJS) => {
+    const { error, user } = addUser({ id: socket.id, ...options });
 
     if (error) {
-      return callbackFromChatJS(error)
+      return callbackFromChatJS(error);
     }
-    socket.join(user.room)
-    socket.emit('messageIndexChat', generateMessage('Chat App by Aleksandar15', 'Welcome!'))
-    socket.broadcast.to(user.room).emit('messageIndexChat', generateMessage('Chat App by Aleksandar15', `${user.username} has joined!`))
-    io.to(user.room).emit('roomUsers', {
+    socket.join(user.room);
+    socket.emit(
+      "messageIndexChat",
+      generateMessage("Chat App by Aleksandar15", "Welcome!")
+    );
+    socket.broadcast
+      .to(user?.room)
+      .emit(
+        "messageIndexChat",
+        generateMessage(
+          "Chat App by Aleksandar15",
+          `${user.username} has joined!`
+        )
+      );
+    io.to(user?.room).emit("roomUsers", {
       room: user.room,
-      users: getUsersInRoom(user.room)
-    })
-    callbackFromChatJS()
-  })
-  socket.on('messageTyped', (messageReceived, callbackIndex) => {
-    const user = getUser(socket.id)
-    const filter = new Filter()
+      users: getUsersInRoom(user.room),
+    });
+    callbackFromChatJS();
+  });
+  socket.on("messageTyped", (messageReceived, callbackIndex) => {
+    const user = getUser(socket.id);
+    const filter = new Filter();
 
-    if(filter.isProfane(messageReceived)) {
-      return callbackIndex('Profanity is not allowed!')
+    if (filter.isProfane(messageReceived)) {
+      return callbackIndex("Profanity is not allowed!");
     }
-    io.to(user.room).emit('messageIndexChat', generateMessage(user.username, messageReceived))
-    callbackIndex()
-  })
-  socket.on('sendLocation', (myCoords, callbackAnyName) => {
-    const user = getUser(socket.id)
-    io.to(user.room).emit('locationIndexChat', generateLocationMessage(user.username, `https://www.google.com/maps?q=${myCoords.latitude},${myCoords.longitude}`))
-    callbackAnyName()
-  })
-  socket.on('disconnect', () => {
-    const user = removeUser(socket.id)
+    io.to(user?.room).emit(
+      "messageIndexChat",
+      generateMessage(user.username, messageReceived)
+    );
+    callbackIndex();
+  });
+  socket.on("sendLocation", (myCoords, callbackAnyName) => {
+    const user = getUser(socket.id);
+    io.to(user?.room).emit(
+      "locationIndexChat",
+      generateLocationMessage(
+        user.username,
+        `https://www.google.com/maps?q=${myCoords.latitude},${myCoords.longitude}`
+      )
+    );
+    callbackAnyName();
+  });
+  socket.on("disconnect", () => {
+    const user = removeUser(socket.id);
 
     if (user) {
-      io.to(user.room).emit('messageIndexChat', generateMessage('Chat App by Aleksandar15', `${user.username} has left!`))
-      io.to(user.room).emit('roomUsers', {
+      io.to(user?.room).emit(
+        "messageIndexChat",
+        generateMessage(
+          "Chat App by Aleksandar15",
+          `${user.username} has left!`
+        )
+      );
+      io.to(user?.room).emit("roomUsers", {
         room: user.room,
-        users: getUsersInRoom(user.room)
-      })
+        users: getUsersInRoom(user.room),
+      });
     }
-  })
-})
+  });
+});
 
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT || 3000;
 // app.listen(PORT, () => {
 server.listen(PORT, () => {
-  console.log(`Server is up and running on port ${PORT}`)
-})
+  console.log(`Server is up and running on port ${PORT}`);
+});

--- a/src/utils/users.js
+++ b/src/utils/users.js
@@ -1,54 +1,54 @@
-const users = []
+const users = [];
 
 // addUser, removeUser, getUser, getUsersInRoom
 const addUser = ({ id, username, room }) => {
   // Clean the data
-  username = username.trim().toLowerCase()
-  room = room.trim().toLowerCase()
+  username = username?.trim().toLowerCase();
+  room = room?.trim().toLowerCase();
 
   // Validate the data
   if (!username || !room) {
     return {
-      error: 'Username and room are required!'
-    }
+      error: "Username and room are required!",
+    };
   }
   // Check for existing user
   const existingUser = users.find((user) => {
-    return user.room === room && user.username === username //We can have same USERNAME but in DIFFERENT ROOMS
-  })
+    return user.room === room && user.username === username; //We can have same USERNAME but in DIFFERENT ROOMS
+  });
   // Validate username
   if (existingUser) {
     return {
-      error: 'Username is already taken!'
-    }
+      error: "Username is already taken!",
+    };
   }
   // Store user
-  const user = { id, username, room }
-  users.push(user)
+  const user = { id, username, room };
+  users.push(user);
   return {
-    user
-  }
-}
+    user,
+  };
+};
 
 const removeUser = (id) => {
-  const index = users.findIndex((user) => user.id === id)
+  const index = users.findIndex((user) => user.id === id);
   if (index !== -1) {
-    return users.splice(index, 1)[0]
+    return users.splice(index, 1)[0];
   }
-}
+};
 
 const getUser = (id) => {
-  return users.find((user) => user.id === id)
-}
+  return users.find((user) => user.id === id);
+};
 
 const getUsersInRoom = (room) => {
-  room = room.trim().toLowerCase()
-  return users.filter((user) => user.room === room)
-}
+  room = room.trim().toLowerCase();
+  return users.filter((user) => user.room === room);
+};
 
 module.exports = {
   addUser,
   removeUser,
   getUser,
-  getUsersInRoom
-}
+  getUsersInRoom,
+};


### PR DESCRIPTION
Fixed a bug where if required link (ex. `https://chat-app-alek/`**`chat.html?username=Alek&room=aleks+room`**) has omitted query strings `username` & `room` it wouldn't redirect & alert the clients that the room is incorrect because of the values being `undefined` ~> Using optional chaining (instead of simple dots notations) fixes the issue.